### PR TITLE
feature/notion-connector

### DIFF
--- a/packages/connectors/notion/package.json
+++ b/packages/connectors/notion/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@trove/connector-notion",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "keywords": [
+    "trove-connector",
+    "notion"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@notionhq/client": "^2.2.15",
+    "@trove/shared": "workspace:*",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/connectors/notion/src/index.ts
+++ b/packages/connectors/notion/src/index.ts
@@ -1,0 +1,220 @@
+import { Client } from "@notionhq/client";
+import type {
+  BlockObjectResponse,
+  PageObjectResponse,
+  RichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+import { z } from "zod";
+import type { Connector, ContentItem, IndexOptions } from "@trove/shared";
+
+const NotionConfigSchema = z.object({
+  token_env: z.string().default("NOTION_TOKEN"),
+  database_ids: z.array(z.string()).min(1),
+});
+
+function richTextToMarkdown(richTexts: RichTextItemResponse[]): string {
+  return richTexts
+    .map((t) => {
+      let text = t.plain_text;
+      if (t.annotations.bold) text = `**${text}**`;
+      if (t.annotations.italic) text = `*${text}*`;
+      if (t.annotations.strikethrough) text = `~~${text}~~`;
+      if (t.annotations.code) text = `\`${text}\``;
+      if (t.href) text = `[${text}](${t.href})`;
+      return text;
+    })
+    .join("");
+}
+
+function getPageTitle(page: PageObjectResponse): string {
+  for (const key of Object.keys(page.properties)) {
+    const prop = page.properties[key];
+    if (prop.type === "title") {
+      return prop.title[0]?.plain_text ?? "Untitled";
+    }
+  }
+  return "Untitled";
+}
+
+function getPageDescription(page: PageObjectResponse): string | undefined {
+  for (const key of Object.keys(page.properties)) {
+    const prop = page.properties[key];
+    if (key.toLowerCase() === "description" && prop.type === "rich_text" && prop.rich_text.length > 0) {
+      return prop.rich_text.map((t) => t.plain_text).join("");
+    }
+  }
+  return undefined;
+}
+
+function blockToMarkdown(block: BlockObjectResponse): string {
+  switch (block.type) {
+    case "paragraph":
+      return `${richTextToMarkdown(block.paragraph.rich_text)}\n\n`;
+    case "heading_1":
+      return `# ${richTextToMarkdown(block.heading_1.rich_text)}\n\n`;
+    case "heading_2":
+      return `## ${richTextToMarkdown(block.heading_2.rich_text)}\n\n`;
+    case "heading_3":
+      return `### ${richTextToMarkdown(block.heading_3.rich_text)}\n\n`;
+    case "bulleted_list_item":
+      return `- ${richTextToMarkdown(block.bulleted_list_item.rich_text)}\n`;
+    case "numbered_list_item":
+      return `1. ${richTextToMarkdown(block.numbered_list_item.rich_text)}\n`;
+    case "to_do":
+      return `- [${block.to_do.checked ? "x" : " "}] ${richTextToMarkdown(block.to_do.rich_text)}\n`;
+    case "toggle":
+      return `${richTextToMarkdown(block.toggle.rich_text)}\n\n`;
+    case "code":
+      return `\`\`\`${block.code.language}\n${richTextToMarkdown(block.code.rich_text)}\n\`\`\`\n\n`;
+    case "quote":
+      return `> ${richTextToMarkdown(block.quote.rich_text)}\n\n`;
+    case "callout":
+      return `> ${richTextToMarkdown(block.callout.rich_text)}\n\n`;
+    case "divider":
+      return `---\n\n`;
+    case "image": {
+      const url = block.image.type === "external"
+        ? block.image.external.url
+        : block.image.file.url;
+      const caption = block.image.caption.length > 0
+        ? richTextToMarkdown(block.image.caption)
+        : "image";
+      return `![${caption}](${url})\n\n`;
+    }
+    case "bookmark":
+      return `[${block.bookmark.url}](${block.bookmark.url})\n\n`;
+    case "equation":
+      return `$$${block.equation.expression}$$\n\n`;
+    default:
+      return "";
+  }
+}
+
+async function fetchPageMarkdown(client: Client, pageId: string): Promise<string> {
+  let markdown = "";
+  let cursor: string | undefined = undefined;
+
+  do {
+    const response = await client.blocks.children.list({
+      block_id: pageId,
+      start_cursor: cursor,
+      page_size: 100,
+    });
+
+    for (const block of response.results) {
+      if ("type" in block) {
+        markdown += blockToMarkdown(block as BlockObjectResponse);
+      }
+    }
+
+    cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+  } while (cursor);
+
+  return markdown.trim();
+}
+
+const connector: Connector = {
+  manifest: {
+    name: "notion",
+    version: "0.1.0",
+    description: "Index Notion databases and pages with metadata and markdown content",
+    configSchema: NotionConfigSchema,
+  },
+
+  async validate(config) {
+    const result = NotionConfigSchema.safeParse(config);
+    if (!result.success) {
+      return {
+        valid: false,
+        errors: result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`),
+      };
+    }
+
+    const token = process.env[result.data.token_env];
+    if (!token) {
+      return {
+        valid: false,
+        errors: [`Missing environment variable: ${result.data.token_env}`],
+      };
+    }
+
+    return { valid: true };
+  },
+
+  async *index(config: Record<string, unknown>, options: IndexOptions) {
+    const parsed = NotionConfigSchema.parse(config);
+    const token = process.env[parsed.token_env];
+
+    if (!token) {
+      throw new Error(`Missing environment variable: ${parsed.token_env}`);
+    }
+
+    const notion = new Client({ auth: token });
+    let indexed = 0;
+
+    for (const dbId of parsed.database_ids) {
+      if (options.signal?.aborted) return;
+
+      let cursor: string | undefined = undefined;
+
+      do {
+        if (options.signal?.aborted) return;
+
+        const response = await notion.databases.query({
+          database_id: dbId,
+          start_cursor: cursor,
+          page_size: 100,
+        });
+
+        for (const page of response.results) {
+          if (options.signal?.aborted) return;
+          if (!("properties" in page)) continue;
+
+          const fullPage = page as PageObjectResponse;
+          const title = getPageTitle(fullPage);
+          let description = getPageDescription(fullPage);
+          let content: string | undefined;
+
+          try {
+            content = await fetchPageMarkdown(notion, fullPage.id);
+            if (!description && content) {
+              const firstLine = content.split("\n").find((l) => l.trim().length > 0);
+              if (firstLine) {
+                description = firstLine.replace(/^[#*\-]\s+/, "").slice(0, 200);
+              }
+            }
+          } catch {
+            content = undefined;
+          }
+
+          const item: ContentItem = {
+            id: `notion:${fullPage.id}`,
+            source: "notion",
+            type: "document",
+            title,
+            description: description ?? `Notion page: ${title}`,
+            tags: [],
+            uri: fullPage.url,
+            metadata: {
+              createdTime: fullPage.created_time,
+              lastEditedTime: fullPage.last_edited_time,
+              icon: fullPage.icon,
+              cover: fullPage.cover,
+              parent: fullPage.parent,
+            },
+            indexedAt: new Date().toISOString(),
+            content,
+          };
+
+          indexed++;
+          options.onProgress?.(indexed);
+          yield item;
+        }
+
+        cursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+      } while (cursor);
+    }
+  },
+};
+
+export default connector;

--- a/packages/connectors/notion/tsconfig.json
+++ b/packages/connectors/notion/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,22 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/connectors/notion:
+    dependencies:
+      '@notionhq/client':
+        specifier: ^2.2.15
+        version: 2.3.0
+      '@trove/shared':
+        specifier: workspace:*
+        version: link:../../shared
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/core:
     dependencies:
       '@trove/shared':
@@ -484,6 +500,10 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@notionhq/client@2.3.0':
+    resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
+    engines: {node: '>=12'}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -636,6 +656,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -725,6 +748,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -799,6 +825,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
@@ -852,6 +882,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -886,6 +920,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
@@ -1015,6 +1053,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1065,6 +1107,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -1209,8 +1255,16 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -1238,6 +1292,15 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -1496,6 +1559,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   turbo-darwin-64@2.8.17:
     resolution: {integrity: sha512-ZFkv2hv7zHpAPEXBF6ouRRXshllOavYc+jjcrYyVHvxVTTwJWsBZwJ/gpPzmOKGvkSjsEyDO5V6aqqtZzwVF+Q==}
     cpu: [x64]
@@ -1635,6 +1701,12 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1967,6 +2039,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@notionhq/client@2.3.0':
+    dependencies:
+      '@types/node-fetch': 2.6.13
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2076,6 +2155,11 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.5.0
+      form-data: 4.0.5
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -2181,6 +2265,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.8: {}
@@ -2259,6 +2345,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@13.1.0: {}
 
   concat-map@0.0.1: {}
@@ -2294,6 +2384,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   dunder-proto@1.0.1:
@@ -2319,6 +2411,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2512,6 +2611,14 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -2554,6 +2661,10 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -2664,7 +2775,13 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -2683,6 +2800,10 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.36: {}
 
@@ -2960,6 +3081,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  tr46@0.0.3: {}
+
   turbo-darwin-64@2.8.17:
     optional: true
 
@@ -3089,6 +3212,13 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
# feat: `@trove/connector-notion`

#1

## Summary

Adds a new connector package `@trove/connector-notion` that indexes Notion databases and pages using the official Notion API (`@notionhq/client`).

## Motivation

Notion is where many creators keep their notes, docs, and project wikis. Making this content searchable via Trove is high-value and was requested in issue #1.

## Changes

### New files

| File | Description |
|------|-------------|
| `packages/connectors/notion/package.json` | Package definition with `@notionhq/client`, `@trove/shared`, and `zod` dependencies |
| `packages/connectors/notion/tsconfig.json` | TypeScript config extending the monorepo base |
| `packages/connectors/notion/src/index.ts` | Full connector implementation |

### No existing files were modified

Only `pnpm-lock.yaml` was updated as a result of adding the new package to the workspace.

## Implementation Details

- **Implements** the `Connector` interface from `@trove/shared` (same pattern as `local` and `github` connectors)
- **Config schema** (Zod):
  - `token_env`: env var name for the Notion token (default: `NOTION_TOKEN`)
  - `database_ids`: array of Notion database IDs to index
- **Validation**: checks config schema and verifies the token env var exists
- **Indexing**:
  - Queries each configured database with full pagination support
  - Extracts page title, description, and URL
  - Converts page block content to Markdown (headings, lists, code blocks, images, quotes, callouts, bookmarks, equations, toggles, to-dos, dividers)
  - Falls back to first content line as description when no explicit description property exists
- **Abort support**: checks `options.signal` at every iteration level
- **Strict typing**: uses `BlockObjectResponse`, `PageObjectResponse`, and `RichTextItemResponse` from the Notion SDK — zero `any` usage
- **Each yielded `ContentItem`** includes:
  - `id`: `notion:{page.id}`
  - `source`: `"notion"`
  - `type`: `"document"`
  - `title`: extracted from the title property
  - `description`: from description property or first line of content
  - `uri`: Notion page URL
  - `metadata`: `createdTime`, `lastEditedTime`, `icon`, `cover`, `parent`
  - `content`: full page content as Markdown

## Configuration Example

```yaml
connectors:
  - use: "@trove/connector-notion"
    with:
      database_ids:
        - "database-id-here"
```

```env
NOTION_TOKEN=secret_xxxxxxxxxxxxx
```

