### PR TITLE
fix: defer incremental cleanup to avoid multi-source deletion

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -76,6 +76,13 @@ export class TroveEngine {
       );
     }
 
+    // Collect all seen IDs per connector name so that incremental cleanup
+    // only runs once per connector — after ALL sources with that connector
+    // have been processed.  This fixes a bug where multiple sources using
+    // the same connector (e.g. several "local" entries) would delete each
+    // other's items during the per-source cleanup phase.
+    const allSeenIdsByConnector = new Map<string, Set<string>>();
+
     for (const source of sources) {
       const connector = await loadConnector(source);
 
@@ -89,7 +96,12 @@ export class TroveEngine {
 
       // Incremental indexing: load existing items to skip unchanged files
       const existingIndex = await this.store.getSourceIndex(source.connector);
-      const seenIds = new Set<string>();
+
+      // Accumulate seen IDs across all sources sharing this connector name
+      if (!allSeenIdsByConnector.has(source.connector)) {
+        allSeenIdsByConnector.set(source.connector, new Set<string>());
+      }
+      const seenIds = allSeenIdsByConnector.get(source.connector)!;
 
       const batch: ContentItem[] = [];
       const BATCH_SIZE = 50;
@@ -124,8 +136,12 @@ export class TroveEngine {
         totalIndexed += batch.length;
         options?.onProgress?.(totalIndexed);
       }
+    }
 
-      // Remove items that no longer exist in the source (deleted files)
+    // Deferred cleanup: remove items that no longer exist in ANY source
+    // sharing the same connector name.
+    for (const [connectorName, seenIds] of allSeenIdsByConnector) {
+      const existingIndex = await this.store.getSourceIndex(connectorName);
       const removedIds = [...existingIndex.keys()].filter(id => !seenIds.has(id));
       if (removedIds.length > 0) {
         await this.store.removeItems(removedIds);


### PR DESCRIPTION
## Summary
- When multiple sources share the same connector name (e.g. several `local` entries), the per-source cleanup was deleting items from previously-indexed sources
- Fix: accumulate `seenIds` across all sources sharing a connector name, then run cleanup once after all sources are processed

Fixes #9

## Test plan
- [ ] Configure 4 `local` sources pointing to different directories
- [ ] Run `trove index` → verify all sources' items are preserved (not just the last one)
- [ ] Run `trove index` again → verify incremental skip works correctly
- [ ] Delete a file, re-index → verify it gets cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)